### PR TITLE
Remove BROKEN from datepicker

### DIFF
--- a/app/views/kanaui/dashboard/index.html.erb
+++ b/app/views/kanaui/dashboard/index.html.erb
@@ -19,13 +19,13 @@
                     <div class="form-group">
                       <div class="col-md-7">
                         <% # TODO datepicker breaks :hover %>
-                        From:<input class="form-control" name="start_date" type="text" data-provide="datepicker-BROKEN" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @start_date %>">
+                        From:<input class="form-control" name="start_date" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @start_date %>">
                       </div>
                     </div>
                     <div class="form-group">
                       <div class="col-md-7">
                         <% # TODO datepicker breaks :hover %>
-                        To:<input class="form-control" name="end_date" type="text" data-provide="datepicker-BROKEN" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @end_date %>">
+                        To:<input class="form-control" name="end_date" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @end_date %>">
                       </div>
                     </div>
                     <% ((@report['variables'] || {})['fields'] || []).each do |definition| %>
@@ -35,7 +35,7 @@
                           <% # TODO Not fully implemented server side %>
                           <% if definition['dataType'] == 'date' %>
                             <% # TODO datepicker breaks :hover %>
-                            <input class="form-control" name="variable_<%= definition['name'] %>" type="text" data-provide="datepicker-BROKEN" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value=""/>
+                            <input class="form-control" name="variable_<%= definition['name'] %>" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value=""/>
                           <% else %>
                             <input class="form-control" name="variable_<%= definition['name'] %>" type="text" value=""/>
                           <% end %>

--- a/app/views/kanaui/dashboard/index.html.erb
+++ b/app/views/kanaui/dashboard/index.html.erb
@@ -2,57 +2,50 @@
   <!--             MENU        -->
   <div class="reports-options flex-inner-left-panel">
     <div class="row">
+    <div class="col-md-12 col-sm-8">
+    <div class="calendar-container">
+      <span class="calendar-icon"><i class="fa fa-calendar"></i><i class="fa fa-caret-down"></i></span>
       <% if params[:name] %>
-        <div class="info-wrapper">
-          <div class="tag-bar tag-bar-breathe">
-            <div class="tag-select" onclick="void(0);">
-                <span><i class="fa fa-calendar"></i><i class="fa fa-caret-down"></i></span>
-
-                <div class="tag-select-box">
-                <%= form_tag kanaui_engine.dashboard_index_path, :class => 'form-horizontal', :method => :get do %>
-                    <input name="name" type="hidden" value="<%= @raw_name %>">
-                    <input name="smooth" type="hidden" value="<%= params[:smooth] %>">
-                    <input name="sql_only" type="hidden" value="<%= params[:sql_only] %>">
-                    <input name="format" type="hidden" value="<%= params[:format] %>">
-                    <input name="delta_days" type="hidden" value="<%= (@end_date.to_date - @start_date.to_date).to_i %>">
-
-                    <div class="form-group">
-                      <div class="col-md-7">
-                        <% # TODO datepicker breaks :hover %>
-                        From:<input class="form-control" name="start_date" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @start_date %>">
-                      </div>
-                    </div>
-                    <div class="form-group">
-                      <div class="col-md-7">
-                        <% # TODO datepicker breaks :hover %>
-                        To:<input class="form-control" name="end_date" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @end_date %>">
-                      </div>
-                    </div>
-                    <% ((@report['variables'] || {})['fields'] || []).each do |definition| %>
-                      <div class="form-group">
-                        <div class="col-md-7">
-                          <%= definition['name'].titleize %>:
-                          <% # TODO Not fully implemented server side %>
-                          <% if definition['dataType'] == 'date' %>
-                            <% # TODO datepicker breaks :hover %>
-                            <input class="form-control" name="variable_<%= definition['name'] %>" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value=""/>
-                          <% else %>
-                            <input class="form-control" name="variable_<%= definition['name'] %>" type="text" value=""/>
-                          <% end %>
-                        </div>
-                      </div>
+        <div class="form-container">
+          <%= form_tag kanaui_engine.dashboard_index_path, :class => 'form-horizontal', :method => :get do %>
+              <input name="name" type="hidden" value="<%= @raw_name %>">
+              <input name="smooth" type="hidden" value="<%= params[:smooth] %>">
+              <input name="sql_only" type="hidden" value="<%= params[:sql_only] %>">
+              <input name="format" type="hidden" value="<%= params[:format] %>">
+              <input name="delta_days" type="hidden" value="<%= (@end_date.to_date - @start_date.to_date).to_i %>">
+              <div class="form-group">
+                <div id="dp1" class="col-md-7">
+                  From:<input class="form-control datepicker" name="start_date" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @start_date %>">
+                </div>
+              </div>
+              <div class="form-group">
+                <div class="col-md-7">
+                  To:<input class="form-control" name="end_date" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value="<%= @end_date %>">
+                </div>
+              </div>
+              <% ((@report['variables'] || {})['fields'] || []).each do |definition| %>
+                <div class="form-group">
+                  <div class="col-md-7">
+                    <%= definition['name'].titleize %>:
+                    <% # TODO Not fully implemented server side %>
+                    <% if definition['dataType'] == 'date' %>
+                      <% # TODO datepicker breaks :hover %>
+                      <input class="form-control" name="variable_<%= definition['name'] %>" type="text" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-today-highlight="true" value=""/>
+                    <% else %>
+                      <input class="form-control" name="variable_<%= definition['name'] %>" type="text" value=""/>
                     <% end %>
-                    <div class="form-group">
-                      <div class="col-sm-12">
-                        <%= submit_tag 'Refresh', :class => 'btn btn-default' %>
-                      </div>
-                    </div>
-                <% end %>
-                </div><!-- /.tag-select-box -->
-            </div><!-- /.tag-select -->
-          </div><!-- /.tag-bar -->
-        </div><!-- /.info-wrapper -->
+                  </div>
+                </div>
+              <% end %>
+              <div class="form-group">
+                <div class="col-sm-12">
+                  <%= submit_tag 'Refresh', :class => 'btn btn-default' %>
+                </div>
+              </div>
+          <% end %>
+        </div>
       <% end %>
+      </div>
       <div class="col-md-12 col-sm-8">
         <h4><%= link_to 'Available Reports', kanaui_engine.url_for(:controller => :reports) %></h4>
           <ul class="nav nav-tabs nav-stacked">
@@ -71,6 +64,7 @@
             </li>
           <% end %>
         </ul>
+      </div>
       </div>
     </div>
     <div class="row">
@@ -182,3 +176,18 @@
     </div>
   </div>
 </div>
+
+
+<%= javascript_tag do %>
+  $(document).ready(function() {
+    $('.calendar-icon').click(function() {
+      $('.form-container').toggle();
+    });
+  });
+<% end %>
+
+<style type="text/css">
+  .form-container {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
The issue raised here: https://github.com/killbill/killbill-admin-ui/issues/389
The issue is due to the hover behavior. When you move your mouse to the datepicker, you’re technically no longer hovering over the form div, so the form disappears.
So I think we can switch from hover to click behavior. This way, the form will stay visible until you click outside of it.