### PR TITLE
Rename killbill-assest-ui to killbill_assets_ui

### DIFF
--- a/lib/kanaui/engine.rb
+++ b/lib/kanaui/engine.rb
@@ -8,7 +8,7 @@
 # See also https://github.com/carlhuda/bundler/issues/49
 require 'js-routes'
 require 'jquery-rails'
-require 'killbill-assets-ui'
+require 'killbill_assets_ui'
 require 'font-awesome-rails'
 require 'bootstrap-datepicker-rails'
 require 'd3_rails'


### PR DESCRIPTION
Rename killbill-assest-ui to killbill_assets_ui.
Related PR: https://github.com/killbill/killbill-assets-ui/pull/8/files